### PR TITLE
Saving data in parquet

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1,10 +1,5 @@
-import credentials
-import src.data_scraper.scraper_binance
-import src.data_scraper.time_helpers
-from src import config
-from src.data_scraper import scraper_twitter, time_helpers
-from src import utils
-import time
+from src.data_scraper.scraper_binance import BinanceScraper
+from src.data_scraper import time_helpers
 
 
 if __name__ == '__main__':
@@ -15,13 +10,13 @@ if __name__ == '__main__':
 
     # Exchange data
     # Dev mode
-    BinanceScraper = src.data_scraper.scraper_binance.BinanceScraper(dev_run=True)
-    training_data = BinanceScraper.get_data(training_start_timestamp, end_timestamp)
+    scraper = BinanceScraper(dev_run=True)
+    training_data = scraper.get_data(training_start_timestamp, end_timestamp)
     print(training_data.tail())
 
     # Prod mode
-    BinanceScraper = src.data_scraper.scraper_binance.BinanceScraper(dev_run=False)
-    prod_data = BinanceScraper.get_data(production_start_timestamp, end_timestamp)
+    scraper = BinanceScraper(dev_run=False)
+    prod_data = scraper.get_data(production_start_timestamp, end_timestamp)
     print(prod_data.tail())
 
 

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -10,14 +10,14 @@ if __name__ == '__main__':
 
     # Exchange data
     # Dev mode
-    scraper = BinanceScraper(dev_run=True)
-    scraper.load_from_disk(training_start_timestamp, end_timestamp)
-    training_data = scraper.get_data(training_start_timestamp, end_timestamp)
-    print(training_data.tail())
-
+    # scraper = BinanceScraper()
+    # scraper.load_from_disk(training_start_timestamp, end_timestamp)
+    # training_data = scraper.load_from_disk(training_start_timestamp, end_timestamp)
+    # print(training_data.tail())
+    #
     # Prod mode
-    scraper = BinanceScraper(dev_run=False)
-    prod_data = scraper.get_data(production_start_timestamp, end_timestamp)
+    scraper = BinanceScraper()
+    prod_data = scraper.scrape_data(production_start_timestamp, end_timestamp)
     print(prod_data.tail())
 
 

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -11,6 +11,7 @@ if __name__ == '__main__':
     # Exchange data
     # Dev mode
     scraper = BinanceScraper(dev_run=True)
+    scraper.load_from_disk(training_start_timestamp, end_timestamp)
     training_data = scraper.get_data(training_start_timestamp, end_timestamp)
     print(training_data.tail())
 
@@ -18,6 +19,8 @@ if __name__ == '__main__':
     scraper = BinanceScraper(dev_run=False)
     prod_data = scraper.get_data(production_start_timestamp, end_timestamp)
     print(prod_data.tail())
+
+
 
 
 

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -8,46 +8,21 @@ import time
 
 
 if __name__ == '__main__':
-    # TESTING NEW STRUCTURE
     # Initializing the timestamps to use in all data scrapers
     end_timestamp = time_helpers.get_current_timestamp()
     training_start_timestamp = time_helpers.get_training_start_timestamp(end_timestamp=end_timestamp)
     production_start_timestamp = time_helpers.get_production_start_timestamp(end_timestamp=end_timestamp)
 
     # Exchange data
-    BinanceScraper = src.data_scraper.scraper_binance.Binance(dev_run=False)
+    # Dev mode
+    BinanceScraper = src.data_scraper.scraper_binance.BinanceScraper(dev_run=True)
+    training_data = BinanceScraper.get_data(training_start_timestamp, end_timestamp)
+    print(training_data.tail())
 
-    # binance_historical_df = BinanceScraper.get_data(
-    #     start_time=training_start_timestamp, end_time=end_timestamp, overwrite=False)
-    # print(binance_historical_df.head())
-
-    binance_latest_df = BinanceScraper.get_data(
-        start_time=production_start_timestamp, end_time=end_timestamp, overwrite=True)
-    print(binance_latest_df.head())
-
-
-    # Twitter Generic Tweets
-    TwitterGenericScraper = scraper_twitter.TwitterGeneric(dev_run=False)
-
-    # historical_generic_tweets = TwitterGenericScraper.get_data(
-    #     start_timestamp=training_start_timestamp, end_timestamp=end_timestamp, save_checkpoint=False, overwrite=True)
-    # print(historical_generic_tweets.tail())
-
-    latest_generic_tweets = TwitterGenericScraper.get_data(
-        start_timestamp=production_start_timestamp, end_timestamp=end_timestamp, save_checkpoint=False, overwrite=True)
-    print(latest_generic_tweets.tail())
-
-
-    # Twitter Profiles with timestamp
-    TwitterProfilesScraper = scraper_twitter.TwitterProfiles(dev_run=False)
-
-    # historical_profile_tweets = TwitterProfilesScraper.get_data(
-    #     start_timestamp=training_start_timestamp, end_timestamp=end_timestamp, save_checkpoint=False, overwrite=True)
-    # print(historical_profile_tweets.tail())
-
-    latest_profile_tweets = TwitterProfilesScraper.get_data(
-        start_timestamp=production_start_timestamp, end_timestamp=end_timestamp, save_checkpoint=False, overwrite=True)
-    print(latest_profile_tweets.tail())
+    # Prod mode
+    BinanceScraper = src.data_scraper.scraper_binance.BinanceScraper(dev_run=False)
+    prod_data = BinanceScraper.get_data(production_start_timestamp, end_timestamp)
+    print(prod_data.tail())
 
 
 

--- a/src/api_client/api_client.py
+++ b/src/api_client/api_client.py
@@ -5,11 +5,16 @@ class BinanceClient:
     def __init__(self, key, secret, **kwargs):
         self.client = Client(api_key=key, api_secret=secret)
 
-    def get_exchange_rates(self, currency_to_buy, currency_to_sell, interval, start_time, end_time):
+    def get_exchange_rates(self, currency_pair, interval, start_time, end_time):
         """
-        start_str | end_str : Date string in UTC format or timestamp in milliseconds.
+        Get historical exchange rates for a currency pair from Binance
+        :param currency_pair: Currency to buy & currency to sell (ex.: BTCEUR)
+        :param interval: 1m, 5m, 15m, 1h, 2h, 4h, 6h, 8h, 1d, 3d, etc.
+        :param start_time: Date string in UTC format or timestamp in milliseconds.
+        :param end_time: Date string in UTC format or timestamp in milliseconds.
+        :return:
         """
-        response = self.client.get_historical_klines(symbol=f'{currency_to_buy}{currency_to_sell}',
+        response = self.client.get_historical_klines(symbol=currency_pair,
                                                      interval=interval,
                                                      start_str=start_time,
                                                      end_str=end_time)

--- a/src/config.py
+++ b/src/config.py
@@ -45,7 +45,7 @@ LATEST_DATA_LOOKBACK_MIN = 240
 MERGE_DATA_ON = 'exact_time'
 
 # Feature generators test
-FEATURE_GENERATORS = [#TimestampGenerator(input_column_names="Timestamp (ms)"),
+FEATURE_GENERATORS = [TimestampGenerator(input_column_names="Timestamp (ms)"),
                       TalippGenerator(EMA, input_column_names="BTCEUR_Close", period=5),
                       TalippGenerator(EMA, input_column_names="BTCEUR_Close", period=15),
                       TalippGenerator(EMA, input_column_names="BTCEUR_Close", period=30),

--- a/src/config.py
+++ b/src/config.py
@@ -45,7 +45,7 @@ LATEST_DATA_LOOKBACK_MIN = 240
 MERGE_DATA_ON = 'exact_time'
 
 # Feature generators test
-FEATURE_GENERATORS = [TimestampGenerator(input_column_names="datetime"),
+FEATURE_GENERATORS = [TimestampGenerator(input_column_names="Timestamp (ms)"),
                       TalippGenerator(EMA, input_column_names="BTCEUR_Close", period=5),
                       TalippGenerator(EMA, input_column_names="BTCEUR_Close", period=15),
                       TalippGenerator(EMA, input_column_names="BTCEUR_Close", period=30),

--- a/src/config.py
+++ b/src/config.py
@@ -45,7 +45,7 @@ LATEST_DATA_LOOKBACK_MIN = 240
 MERGE_DATA_ON = 'exact_time'
 
 # Feature generators test
-FEATURE_GENERATORS = [TimestampGenerator(input_column_names="Timestamp (ms)"),
+FEATURE_GENERATORS = [#TimestampGenerator(input_column_names="Timestamp (ms)"),
                       TalippGenerator(EMA, input_column_names="BTCEUR_Close", period=5),
                       TalippGenerator(EMA, input_column_names="BTCEUR_Close", period=15),
                       TalippGenerator(EMA, input_column_names="BTCEUR_Close", period=30),

--- a/src/data_scraper/scraper_binance.py
+++ b/src/data_scraper/scraper_binance.py
@@ -29,9 +29,6 @@ class BinanceScraper:
         self.col_names = ['Timestamp (ms)', 'Open', 'High', 'Low', 'Close', 'Volume', 'Close time', 'Quote asset volume',
                           'Number of trades', 'Taker buy base asset volume', 'Taker buy quote asset volume', 'Ignore']
         self.datatypes = [int, float, float, float, float, float, int, float, int, float, float, int]
-
-        # self.dataset_path = f"{config.FOLDER_TO_SAVE}/{self.name}"
-        # self.dataset_name = f"{self.currency_to_buy}{self.currency_to_sell}"
         self.dataset_path = f"{config.FOLDER_TO_SAVE}/{self.name}/{self.currency_to_buy}{self.currency_to_sell}"
         self.cache_data = None
 
@@ -86,8 +83,7 @@ class BinanceScraper:
         :return: None
         """
         if not self.dataset_stored(start_time, end_time):
-            window_before_start_time = time_helpers.get_production_start_timestamp(start_time)
-            for chunk_start, chunk_end in time_helpers.slice_timestamps_in_chunks(window_before_start_time, end_time):
+            for chunk_start, chunk_end in time_helpers.slice_timestamps_in_chunks(start_time, end_time):
                 data = self.scrape_data(chunk_start, chunk_end)
                 utils.save_data(data, self.dataset_path)
         data = pq.read_table(source=self.dataset_path).to_pandas()

--- a/src/data_scraper/scraper_binance.py
+++ b/src/data_scraper/scraper_binance.py
@@ -48,6 +48,7 @@ class BinanceScraper:
     def scrape_data(self, start_time, end_time):
         """
         Scrape the data from the Binance API. Operates in UTC timezone.
+        :return: pd.DataFrame
         """
         df = pd.DataFrame(columns=self.col_names_and_dtypes)
 
@@ -60,11 +61,12 @@ class BinanceScraper:
             # Setting the right data types to save later as metadata in parquet
             temp_df = temp_df.astype(self.col_names_and_dtypes)
 
+            # Drop the "Ignore" column that Binance sends by default
+            temp_df = temp_df.drop('Ignore', axis=1)
+
             # Rename the columns, except for merger column
             temp_df = temp_df.rename(columns={f'{col}': f'{currency_pair}_{col}' for col in temp_df.columns
                                               if col != 'Timestamp (ms)'})
-
-            temp_df = temp_df.drop('Ignore', axis=1)  # Drop the "Ignore" column that Binance sends
 
             if len(df) == 0:
                 df = temp_df.copy()
@@ -81,7 +83,8 @@ class BinanceScraper:
 
     def get_stored_data(self, start_time, end_time):
         """
-        Returns the exact slice of cached data that is between start and end timestamp.
+        Get the exact slice of cached data between start and end timestamp.
+        :return: pd.DataFrame
         """
         data = self.cache_data.loc[(self.cache_data["Timestamp (ms)"] > start_time) &
                                    (self.cache_data["Timestamp (ms)"] <= end_time), :]

--- a/src/data_scraper/scraper_binance.py
+++ b/src/data_scraper/scraper_binance.py
@@ -1,7 +1,10 @@
 import os
 from functools import partial
+from dateutil import parser
 
 import pandas as pd
+import pyarrow.parquet as pq
+import pyarrow as pa
 
 import credentials
 from src import config
@@ -22,66 +25,92 @@ class BinanceScraper:
         all_currencies.remove(self.currency_to_buy)
         self.currency_pairs = [f'{self.currency_to_buy}{self.currency_to_sell}',
                                *[f'{currency}{self.currency_to_sell}' for currency in all_currencies]]
-        self.col_names = ['Open time', 'Open', 'High', 'Low', 'Close', 'Volume', 'Close time', 'Quote asset volume',
+        self.col_names = ['Timestamp (ms)', 'Open', 'High', 'Low', 'Close', 'Volume', 'Close time', 'Quote asset volume',
                           'Number of trades', 'Taker buy base asset volume', 'Taker buy quote asset volume', 'Ignore']
+        self.datatypes = [int, float, float, float, float, float, int, float, int, float, float, int]
 
         self.dataset_path = f"{config.FOLDER_TO_SAVE}/binance"
         self.dataset_name = f"{self.currency_to_buy}{self.currency_to_sell}"
 
-    def get_data(self, start_time, end_time):
-        """Get Binance API exchange rates for all selected currencies. Operates in UTC timezone.
-        By default, it will try to continue from the latest available data point if the last saved timestamp is ahead
-        of the timestamp specified in the config, to save time instead of loading already available data."""
-
+    def scrape_data(self, start_time, end_time):
+        """
+        Get Binance API exchange rates for all selected currencies. Operates in UTC timezone.
+        """
         df = pd.DataFrame(columns=self.col_names)
 
         for currency_pair in self.currency_pairs:
-            start_time_datetime = time_helpers.timestamp_to_str(start_time, format="exact_time")
-            end_time_datetime = time_helpers.timestamp_to_str(end_time, format="exact_time")
             klines = self.client.get_exchange_rates(
                 currency_to_buy=self.currency_to_buy, currency_to_sell=self.currency_to_sell,
-                interval=self.interval, start_time=start_time_datetime, end_time=end_time_datetime)
+                interval=self.interval, start_time=start_time, end_time=end_time)
 
             temp_df = pd.DataFrame(klines, columns=self.col_names)
-            temp_df[config.MERGE_DATA_ON] = temp_df['Open time'].apply(partial(
-                time_helpers.timestamp_to_str, format='exact_time'))
+
+            # Setting the right data types to save later as metadata in parquet
+            temp_df = temp_df.astype({col_name: dtype for col_name, dtype in zip(self.col_names, self.datatypes)})
 
             # Rename the columns, except for merger column
             temp_df = temp_df.rename(columns={f'{col}': f'{currency_pair}_{col}' for col in temp_df.columns
-                                              if col != config.MERGE_DATA_ON})
-
-            if len(temp_df) == 0:
-                print(f'{currency_pair}_{self.interval} skipped.')
+                                              if col != 'Timestamp (ms)'})
 
             if len(df) == 0:
                 df = temp_df.copy()
             else:
-                df = df.merge(temp_df, how='outer', on=config.MERGE_DATA_ON)
+                df = df.merge(temp_df, how='outer', on='Timestamp (ms)')
 
-        # Creating general datetime column in seconds
-        df["datetime"] = df[f"{currency_pair}_Open time"]
+        # Getting the merger column
+        df[config.MERGE_DATA_ON] = pd.to_datetime(df['Timestamp (ms)'], unit='ms')
+
+        # Date column to partition by with parquet later
+        df['date'] = df[config.MERGE_DATA_ON].dt.date
 
         return df
 
-    def load_dataset(self, start_time, end_time):
-        full_dataset_name = f"{self.dataset_name}_{start_time}_{end_time}"
-        if self.dataset_not_stored(full_dataset_name):
-            to_store_dataset = self.get_data(start_time, end_time)
-            to_store_dataset.to_csv(f"{self.dataset_path}/{full_dataset_name}")
-            self.cache_dataset = to_store_dataset
+    def get_data(self, start_time, end_time):
+        """
+        Load the exchange data from Binance. Always scrapes data in production.
+        Tries to load data from disk in development. If it is not possible, scrapes the data and saves in parquet.
+        """
+        if not self.dev_run:  # Always scrape if in production
+            return self.scrape_data(start_time, end_time)
+        else:  # Try loading from disk if in development
+            self.load_from_disk(start_time, end_time)
+            return self.get_stored_data(end_time, start_time)
+
+    def load_from_disk(self, start_time, end_time):
+        if self.dataset_not_stored(start_time, end_time):
+            data = self.scrape_data(start_time, end_time)
+            table = pa.Table.from_pandas(data)  # Save the loaded data if in development/training
+            pq.write_to_dataset(table, root_path=f"{self.dataset_path}/{self.dataset_name}", partition_cols=['date'])
+            self.cache_dataset = data
         else:
-            self.cache_dataset = pd.read_csv(f"{self.dataset_path}/{full_dataset_name}")
+            self.cache_dataset = pq.read_table(source=f"{self.dataset_path}/{self.dataset_name}").to_pandas()
 
-        self.cache_dataset[config.MERGE_DATA_ON] = pd.to_datetime(self.cache_dataset[config.MERGE_DATA_ON],
-                                                                  infer_datetime_format=True)
+    def dataset_not_stored(self, start_time, end_time):
+        """
+        Checks availability of stored data on disk for selected start and end dates.
+        The data is available if requested start date >= saved start date and requested end date >= saved end date.
+        """
+        full_path = f"{self.dataset_path}/{self.dataset_name}"
+        if os.path.exists(full_path):
+            available_dates = os.listdir(full_path)
+            available_dates = [date.split('date=')[-1] for date in available_dates if not date.startswith('.')]
+            available_dates = [parser.parse(date).date() for date in available_dates]
 
-    def dataset_not_stored(self, full_dataset_name):
-        return not os.path.exists(f"{self.dataset_path}/{full_dataset_name}")
+            start_date = time_helpers.timestamp_to_datetime(start_time).date()
+            end_date = time_helpers.timestamp_to_datetime(end_time).date()
+
+            if not start_date >= min(available_dates) and end_date <= max(available_dates):
+                return True
+        else:
+            return True
 
     def get_stored_data(self, start_time, end_time):
+        """
+        Returns the exact slice of exchange data that is between start and end timestamp.
+        """
         data =  self.cache_dataset.loc[
-               (self.cache_dataset["datetime"] > start_time) & (
-                           self.cache_dataset["datetime"] <= end_time), :]
+               (self.cache_dataset["Timestamp (ms)"] > start_time) & (
+                           self.cache_dataset["Timestamp (ms)"] <= end_time), :]
 
         if len(data) == 0:
             raise RuntimeError("No more data")

--- a/src/data_scraper/time_helpers.py
+++ b/src/data_scraper/time_helpers.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import src.config as config
 import datetime as dt
 from dateutil import parser
@@ -15,7 +17,7 @@ def get_training_start_timestamp(end_timestamp):
 
 
 def get_production_start_timestamp(end_timestamp):
-    """Gets the prodiction starting timestamp X amount of days ago, specified in config.LATEST_DATA_LOOKBACK_MIN."""
+    """Gets the production start timestamp X amount of minutes ago, specified in config.LATEST_DATA_LOOKBACK_MIN."""
     return end_timestamp - (1000 * 60 * config.LATEST_DATA_LOOKBACK_MIN)
 
 
@@ -36,7 +38,7 @@ def timestamp_to_str(timestamp, format: ['date', 'exact_time']):
     if format == 'date':
         return timestamp_to_datetime(timestamp).strftime('%Y-%m-%d')
     elif format == 'exact_time':
-        return timestamp_to_datetime(timestamp).strftime('%Y-%m-%d %H:%M:%S+00:00') # UTC
+        return timestamp_to_datetime(timestamp).strftime('%Y-%m-%d %H:%M:%S+00:00')  # UTC
     else:
         raise Exception('Format has to be either "date" or "exact_time".')
 
@@ -69,3 +71,43 @@ def str_to_timestamp(string, format: ['date', 'exact_time']):
         return int(round(dt.datetime.strptime(string, "%Y-%m-%d %H:%M:%S").timestamp())) * 1000
     else:
         raise Exception('Format has to be either "date" or "exact_time".')
+
+
+def slice_timestamps_in_chunks(start_timestamp, end_timestamp):
+    """
+    Slice the full timeframe between start and end timestamps into weekly chunks.
+    The purpose is to avoid API crashes when loading large timeframes of data.
+    If the total timeframe does not sum up to a round number of weeks, the last week is kept as it is.
+    All starting timestamps in chunks are shifted by the production lookback window.
+    :param start_timestamp: timestamp in ms
+    :param end_timestamp: timestamp in ms
+    :return: [[chunk_start, chunk_end], [chunk_start, chunk_end], ...]
+    """
+    one_week_ms = 1000 * 60 * 60 * 24 * 7  # ms * s * m * h * d
+    full_weeks = (end_timestamp - start_timestamp) // one_week_ms
+    total_weeks = (end_timestamp - start_timestamp) / one_week_ms
+
+    # If total time frame is less than one week, return the original timestamps with a lookback window
+    if total_weeks < 1:
+        return [[get_production_start_timestamp(start_timestamp), end_timestamp]]
+
+    # Split complete weeks into one-week-chunks
+    chunks = []
+    for week in range(full_weeks):
+        chunk_start = start_timestamp + (week * one_week_ms)
+        chunk_end = chunk_start + one_week_ms
+        chunks.append([chunk_start, chunk_end])
+
+    # Append last incomplete week
+    if not full_weeks == total_weeks:
+        last_chunk_start = chunks[-1][-1]
+        last_chunk_end = end_timestamp
+        chunks.append([last_chunk_start, last_chunk_end])
+
+    # Shift all start timestamps by the production lookback window
+    chunks = [[get_production_start_timestamp(chunk[0]), chunk[1]] for chunk in chunks]
+
+    # # ALTERNATIVE: Shift only the first start timestamp by the production lookback window
+    # chunks[0][0] = time_helpers.get_production_start_timestamp(chunks[0][0])
+
+    return chunks

--- a/src/order_executer/app.py
+++ b/src/order_executer/app.py
@@ -5,7 +5,7 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from flask import Flask, render_template, redirect, url_for, request
 
 from credentials import BINANCE_API_KEY, BINANCE_API_SECRET
-from src.data_scraper.binance_scraper import BinanceScraper
+from src.data_scraper.scraper_binance import BinanceScraper
 from src.order_executer.service.data_service import ProductionDataService
 from src.order_executer.ui import active_screen
 from src.order_executer.service.order_executer import OrderExecuter

--- a/src/order_executer/scripts/dev_run.py
+++ b/src/order_executer/scripts/dev_run.py
@@ -4,8 +4,8 @@ from src.order_executer.service.logger import Logger
 from src.order_executer.service.order_executer import OrderExecuter
 from src.order_executer.service.portfolio import Portfolio
 
-data_service = TrainingDataService(interval_period_in_minutes=1, channels=[BinanceScraper()], start_time="2021-11-01",
-                                   end_time="2021-11-05")
+data_service = TrainingDataService(interval_period_in_minutes=1, channels=[BinanceScraper(dev_run=True)],
+                                   start_time="2021-11-02", end_time="2021-11-05")
 
 portfolios = [Portfolio("test", "key", "pass")]
 logger = Logger("logs.csv")

--- a/src/order_executer/scripts/dev_run.py
+++ b/src/order_executer/scripts/dev_run.py
@@ -5,7 +5,7 @@ from src.order_executer.service.order_executer import OrderExecuter
 from src.order_executer.service.portfolio import Portfolio
 
 data_service = TrainingDataService(interval_period_in_minutes=1, channels=[BinanceScraper()],
-                                   start_date="2021-11-01", end_date="2021-12-13")
+                                   start_date="2020-01-01", end_date="2021-12-13")
 
 portfolios = [Portfolio("test", "key", "pass")]
 logger = Logger("logs.csv")

--- a/src/order_executer/scripts/dev_run.py
+++ b/src/order_executer/scripts/dev_run.py
@@ -4,8 +4,8 @@ from src.order_executer.service.logger import Logger
 from src.order_executer.service.order_executer import OrderExecuter
 from src.order_executer.service.portfolio import Portfolio
 
-data_service = TrainingDataService(interval_period_in_minutes=1, channels=[BinanceScraper(dev_run=True)],
-                                   start_time="2021-11-02", end_time="2021-11-05")
+data_service = TrainingDataService(interval_period_in_minutes=1, channels=[BinanceScraper()],
+                                   start_date="2021-11-01", end_date="2021-12-13")
 
 portfolios = [Portfolio("test", "key", "pass")]
 logger = Logger("logs.csv")

--- a/src/order_executer/service/data_service.py
+++ b/src/order_executer/service/data_service.py
@@ -1,8 +1,7 @@
-
 from src.data_scraper import time_helpers
 
-class ProductionDataService:
 
+class ProductionDataService:
     def __init__(self, interval_period_in_minutes, channels):
         self.interval_period_in_minutes = interval_period_in_minutes
         self.channels = channels

--- a/src/order_executer/service/data_service.py
+++ b/src/order_executer/service/data_service.py
@@ -1,4 +1,5 @@
 from src.data_scraper import time_helpers
+from src import config
 
 
 class ProductionDataService:
@@ -33,14 +34,26 @@ class ProductionDataService:
 
 
 class TrainingDataService:
-    def __init__(self, interval_period_in_minutes, channels, start_time, end_time):
+    def __init__(self, interval_period_in_minutes, channels, start_date, end_date):
+        """
+        Tries loading saved data from disk if possible. Otherwise, scrapes it first.
+        The starting exact time will be 00:00 of the requested start date and 23:59 of the end date.
+        :param interval_period_in_minutes: Time interval between data samples
+        :param channels: Data scrapers of choice
+        :param start_date: YYYY-MM-DD date written as string
+        :param end_date: YYYY-MM-DD date written as string
+        """
         self.interval_period_in_minutes = interval_period_in_minutes
         self.channels = channels
-        self.start_time = time_helpers.str_to_timestamp(start_time, format="date")
-        self.end_time = time_helpers.str_to_timestamp(end_time, format="date")
+        self.start_timestamp = time_helpers.str_to_timestamp(start_date, format='date')
+        self.start_timestamp = time_helpers.get_start_of_the_day(self.start_timestamp)  # Start will be at 00:00
+
+        self.end_timestamp = time_helpers.str_to_timestamp(end_date, format='date')
+        self.end_timestamp = time_helpers.get_end_of_the_day(self.end_timestamp)
+        self.end_timestamp = time_helpers.adjust_last_possible_timestamp(self.end_timestamp)  # End will be at 23:59
 
         # First timestamp
-        self.last_end_time = start_time
+        self.last_end_timestamp = self.start_timestamp
 
     def initialize(self):
         """
@@ -48,13 +61,13 @@ class TrainingDataService:
         :return: Dictionary with data for each channel
         """
         print("Initializing Training Data Service")
-        window_before_start_time = time_helpers.get_production_start_timestamp(self.start_time)
+        window_after_start_time = self.start_timestamp + (1000 * 60 * config.LATEST_DATA_LOOKBACK_MIN)
         for channel in self.channels:
-            channel.load_from_disk(window_before_start_time, self.end_time)
+            channel.load_from_disk(self.start_timestamp, self.end_timestamp)
 
-        self.last_end_time = self.start_time
+        self.last_end_timestamp = window_after_start_time
 
-        return self.get_channel_data(window_before_start_time, self.start_time)
+        return self.get_channel_data(self.start_timestamp, window_after_start_time)
 
     def get_channel_data(self, start, end):
         data = {}
@@ -67,9 +80,9 @@ class TrainingDataService:
         Gets data between the start timestamp and the interval_period_in_minutes.
         :return: Dictionary with data for each channel
         """
-        start = self.last_end_time
+        start = self.last_end_timestamp
         end = start + 1000 * 60 * self.interval_period_in_minutes
-        self.last_end_time = end
+        self.last_end_timestamp = end
         return self.get_channel_data(start, end)
 
 

--- a/src/order_executer/service/data_service.py
+++ b/src/order_executer/service/data_service.py
@@ -51,7 +51,7 @@ class TrainingDataService:
         print("Initializing Training Data Service")
         window_before_start_time = time_helpers.get_production_start_timestamp(self.start_time)
         for channel in self.channels:
-            channel.load_dataset(window_before_start_time, self.end_time)
+            channel.load_from_disk(window_before_start_time, self.end_time)
 
         self.last_end_time = self.start_time
 
@@ -60,7 +60,7 @@ class TrainingDataService:
     def get_channel_data(self, start, end):
         data = {}
         for channel in self.channels:
-            data[channel.name] = channel.get_slice(start, end)
+            data[channel.name] = channel.get_stored_data(start, end)
         return data
 
     def get_data(self):

--- a/src/order_executer/service/data_service.py
+++ b/src/order_executer/service/data_service.py
@@ -60,7 +60,7 @@ class TrainingDataService:
     def get_channel_data(self, start, end):
         data = {}
         for channel in self.channels:
-            data[channel.name] = channel.get_stored_data(start, end)
+            data[channel.name] = channel.get_slice(start, end)
         return data
 
     def get_data(self):

--- a/src/order_executer/service/order_executer.py
+++ b/src/order_executer/service/order_executer.py
@@ -53,7 +53,7 @@ class OrderExecuter:
                 return
             self.feature_service.add_value(price_data, purging=True)
             # Model will return 1, 0 or -1 if price goes above or below 1%
-            predictions = {"BTCEUR": random.randint(0, 1)}
+            predictions = {"BTCEUR": random.randint(-1, 1)}
             self.portfolio_manager.calculate_movements(predictions)
 
             if self.logger:

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,45 +1,18 @@
 import src.config as config
 import os
 import pandas as pd
+import pyarrow.parquet as pq
+import pyarrow as pa
 
 
-def save(data, subfolder, filename, overwrite=False):
-    """WIP. Save the loaded data. If a file already exists, it will try to append to it by columns or indexes.
-    If duplicates exist, it will only preserve the last, remove the previous ones, and save the file again."""
-    os.makedirs(os.path.join(config.FOLDER_TO_SAVE, subfolder), exist_ok=True)
-    if overwrite:
-        data.to_csv(os.path.join(config.FOLDER_TO_SAVE, subfolder, filename), index=False)
-    else:
-        if filename in os.listdir(os.path.join(config.FOLDER_TO_SAVE, subfolder)):
-            saved_data = pd.read_csv(os.path.join(config.FOLDER_TO_SAVE, subfolder, filename))
-            data = data.astype(object)
-            saved_data = saved_data.astype(object)
-            if sorted(data.columns.tolist()) == sorted(saved_data.columns.tolist()):
-                data = pd.merge(data, saved_data, how='outer', on=data.columns.tolist())
-            else:
-                # Find common columns to merge on
-                common_cols = data.columns[data.columns.isin(saved_data.columns)].tolist()
-                data = data.merge(saved_data, how='outer', on=common_cols, copy=False)
-
-        data = data.groupby(config.MERGE_DATA_ON).last().reset_index()
-        data = data.sort_values(by=config.MERGE_DATA_ON)
-        data.to_csv(os.path.join(config.FOLDER_TO_SAVE, subfolder, filename), index=False)
-
-
-def load_from_checkpoint(subfolder, filename, start_time, end_time):
-    """WIP"""
-    if filename in os.listdir(os.path.join(config.FOLDER_TO_SAVE, subfolder)):
-        test = pd.read_csv(f'{config.FOLDER_TO_SAVE}/{subfolder}/{filename}')
-        # If the last timestamp in the saved file > specified end timestamp
-        if test['exact_time'].astype('datetime64[ns]').iloc[-1] > end_time:
-            if test.iloc[0]['exact_time'] < start_time:
-                print('File already saved.')
-            else:
-                end_time = int(test.iloc[0]['exact_time'])
-
-        # If the last timestamp in the saved file > specified start timestamp, use the df's latest one
-        if test['exact_time'].iloc[-1] > start_time:
-            if test['exact_time'].iloc[0] < start_time:
-                start_time = int(test.iloc[-2]['exact_time'])
-
-    return start_time, end_time
+def save_data(data, dataset_path) -> None:
+    """
+    Save the loaded data if in development/training in parquet, partitioned by week.
+    :param data: pd.DataFrame
+    :param dataset_path: Scraper folder (specify as an attribute of the scraper)
+    :param dataset_name: Specific dataset of the scraper (specify as an attribute of the scraper)
+    :return: None
+    """
+    os.makedirs(dataset_path, exist_ok=True)
+    table = pa.Table.from_pandas(df=data)
+    pq.write_to_dataset(table, root_path=dataset_path, partition_cols=['date'])

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,8 +1,26 @@
-import src.config as config
 import os
-import pandas as pd
+from dateutil import parser
 import pyarrow.parquet as pq
 import pyarrow as pa
+from src.data_scraper import time_helpers
+
+
+def dataset_stored(dataset_path, start_time, end_time) -> bool:
+    """
+    Checks availability of stored data on disk for selected start and end dates.
+    The data is available if requested start date >= saved start date and requested end date >= saved end date.
+    """
+    if os.path.exists(dataset_path):
+        available_dates = os.listdir(dataset_path)
+        available_dates = [date.split('date=')[-1] for date in available_dates if not date.startswith('.')]
+        available_dates = [parser.parse(date).date() for date in available_dates]
+
+        start_date = time_helpers.timestamp_to_datetime(start_time).date()
+        end_date = time_helpers.timestamp_to_datetime(end_time).date()
+
+        return start_date >= min(available_dates) and end_date <= max(available_dates)
+    else:
+        return False
 
 
 def save_data(data, dataset_path) -> None:


### PR DESCRIPTION
Saves data partitioned by `date`. Loads and saves it in chunks of one week to prevent API crashes. Right now, if there's an overlap between already saved and newly loaded data, it will save both versions. When loading, it only takes the most recent version to avoid duplicates.